### PR TITLE
CASMPET-5162 master : Release cray-s3 for csm-1.2

### DIFF
--- a/kubernetes/cray-s3/Chart.yaml
+++ b/kubernetes/cray-s3/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: cray-s3
 description: Exposes Ceph Rados gateways
-version: 0.2.0
+version: 1.0.0


### PR DESCRIPTION
Prepare for release of cray-s3 for csm-1.2
Includes
* CASMPET-5152 : cray-s3 service needs to move to CMN

Stash csm-1.0 branch is currently using Chart version 0.2.0 so bumping to 1.0.0 to provide possible 0.3.0 if needed for csm 1.1 and to note that the change is not backward compatible
